### PR TITLE
Remove common Micro.blog elements from head and use new partial instead

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,42 +11,11 @@
 
   <meta name="description" content="{{ .Summary }}">
 
-  <link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
   <link rel="stylesheet" href="{{ "css/simple.min.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
   {{ partial "style.html" . }}
   <link rel="stylesheet" href="{{ "css/fontawesome.min.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
   <link rel="stylesheet" href="{{ "css/brands.min.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
   <link rel="stylesheet" href="{{ "css/solid.min.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
-  <link rel="stylesheet" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
   <link rel="canonical" href="{{ .Permalink }}">
-
-    {{ if .RSSLink -}}
-      <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-      <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
-      <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
-      <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
-    {{ end -}}
-
-	<link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
-	{{ with .Site.Params.twitter_username }}
-		<link rel="me" href="https://twitter.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.github_username }}
-		<link rel="me" href="https://github.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.instagram_username }}
-		<link rel="me" href="https://instagram.com/{{ . }}" />
-	{{ end }}
-	<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
-	<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
-	<link rel="micropub" href="https://micro.blog/micropub" />
-	<link rel="microsub" href="https://micro.blog/microsub" />
-	<link rel="webmention" href="https://micro.blog/webmention" />
-	<link rel="subscribe" href="https://micro.blog/users/follow" />
-    {{ range .Site.Params.plugins_css }}
-	    <link rel="stylesheet" href="{{ . }}" />
-    {{ end }}
-    {{ range $filename := .Site.Params.plugins_html }}
-    	{{ partial $filename $ }}
-    {{ end }}
+  {{ partial "microblog_head.html" . }}
 </head>


### PR DESCRIPTION
Gateway now uses the new partial. I tested locally on Hugo 0.91 and 0.117 and everything looks okay. By design, this theme lacks a list of posts on the homepage. So, naturally, some tests fail:

- Feed microformats are present on homepage ... FAILED
- Post entry have valid microformats on homepage ... FAILED
- Micropost entry have valid microformats on homepage … FAILED

That's expected and was happening before this change.